### PR TITLE
Use size property for tooltips

### DIFF
--- a/client/views/components/Tooltip.vue
+++ b/client/views/components/Tooltip.vue
@@ -122,14 +122,14 @@
           <h1 class="title">Sizes</h1>
           <div class="columns is-multiline is-mobile">
             <div class="column">
-              <tooltip label="small" type="small" placement="bottom-right">
+              <tooltip label="small" size="small" placement="bottom-right">
                 <button class="button has-text-centered">
                   <span>small</span>
                 </button>
               </tooltip>
             </div>
             <div class="column">
-              <tooltip label="medium" type="medium">
+              <tooltip label="medium" size="medium">
                 <button class="button has-text-centered">
                   <span>medium</span>
                 </button>


### PR DESCRIPTION
The small tooltip in the documentation is actually not small, its medium. 

<img width="291" alt="bildschirmfoto 2017-08-31 um 14 52 48" src="https://user-images.githubusercontent.com/174685/29924127-273a6722-8e5c-11e7-8828-0883f6555b96.png">

<img width="420" alt="bildschirmfoto 2017-08-31 um 14 52 57" src="https://user-images.githubusercontent.com/174685/29924132-2cdf05ca-8e5c-11e7-952f-62110d1cd711.png">


This seems to be an issue with vue-bulma/tooltip when using the `type` property. When you try to use it with type `small` `tooltip--small` and `tooltip--medium` gets applied.

https://github.com/vue-bulma/tooltip/blob/master/src/index.js#L55

I think its safe for now to just use the size `property`.