### PR TITLE
Relative build path support

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -32,7 +32,10 @@ exports.cssLoaders = options => {
     if (options.extract) {
       return ExtractTextPlugin.extract({
         use: sourceLoader,
-        fallback: 'vue-style-loader'
+        fallback: 'vue-style-loader',
+        // Fixed the problem that the URLs of fonts and images in the css files are incorrect
+        // when assetsPublicPath set to './' in production environment
+        publicPath: '../../'
       })
     } else {
       return ['vue-style-loader', sourceLoader].join('!')

--- a/config/index.js
+++ b/config/index.js
@@ -9,7 +9,7 @@ module.exports = {
     index: path.resolve(__dirname, '../dist/index.html'),
     assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'assets',
-    assetsPublicPath: '/',
+    assetsPublicPath: './',
     productionSourceMap: true,
     // Gzip off by default as many popular static hosts such as
     // Surge or Netlify already gzip all static assets for you.


### PR DESCRIPTION
Fixed the problem that the URLs of fonts and images in the CSS files are incorrect when `assetsPublicPath` set to `./` in production environment.
Now the 'dist' directory can be visited by any URL root path at the same time.
For example: 
visit `http://192.168.1.101/project/` in intranet, 
and visit `http://project.example.com/` in internet.

修正`assetsPublicPath`被设置成`./`时，CSS文件中的图片、字体等引用地址错误的问题。
现在项目可以支持发布到任意层级的目录。比如在维护主机的内网环境下使用 `http://192.168.1.101/project/`访问主页，同时又可以在广域网下以`http://project.example.com/`这样的根路径访问同一主机。
如果项目地址发生变动，比如从`http://www.example.com/project-a/`变成了`http://www.example.com/project-b/sub-a/`，也仅仅只需要调整项目文件目录，而不需要修改`assetsPublicPath`并重新编译打包。